### PR TITLE
Change +load to +initialize

### DIFF
--- a/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel.m
@@ -40,7 +40,7 @@ static JSONValueTransformer* valueTransformer = nil;
 
 #pragma mark - initialization methods
 
-+(void)load
++(void)initialize
 {
     static dispatch_once_t once;
     dispatch_once(&once, ^{


### PR DESCRIPTION
Using +load seems to cause an issue where the static, class level variables in JSONModel.m (like "allowedJSONTypes") are dealloc'ed before use.  Interestingly, this only seems to happen when you are linking to a compiled library that contains JSONModel instead of pulling the JSONModel source directly into your project.  The reasons for doing so could be numerous, but in my use case I'm trying to create a CocoaPod for JSONModel to facilitate easy integration.

I tested the change from +load to +initialize in both my app (using CocoaPods) and the JSONModel Demo project, and both seem unaffected.  It seems to me that +initialize in general is a better place for this kind of setup code.  See the links below for some of the differences between the two.  The biggest difference, in my mind, is that +load is called _outside_ of a autoreleasepool.  I know that +initialize can be called more than once under certain situations, but since its wrapped in a dispatch_once call anyway that isn't a concern.

http://blog.federicomestrone.com/2011/05/16/objective-c-load-and-initialize/
http://www.friday.com/bbum/2009/09/06/iniailize-can-be-executed-multiple-times-load-not-so-much/
