### PR TITLE
Add @autorelease in JSONModel +load

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -50,10 +50,13 @@ static NSMutableDictionary* keyMappers = nil;
         // initialize all class static objects,
         // which are common for ALL JSONModel subclasses
         
-        allowedJSONTypes = @[
+        @autoreleasepool
+        {
+            allowedJSONTypes = @[
             [NSString class], [NSNumber class], [NSArray class], [NSDictionary class], [NSNull class], //immutable JSON classes
             [NSMutableString class], [NSMutableArray class], [NSMutableDictionary class] //mutable JSON classes
-        ];
+            ];
+        }
         
         allowedPrimitiveTypes = @[
             @"BOOL", @"float", @"int", @"long", @"double", @"short"


### PR DESCRIPTION
JSONModel throws many exceptions like `objc[66731]: Object 0x6c338a0 of class __NSArrayI autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug`
One should not use the +class method in +load without an autorelease pool
