### PR TITLE
Change isEqualToString to isKindOfClass

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -531,7 +531,7 @@ static NSMutableDictionary* keyMappers = nil;
     if ([[protocolClass class] isSubclassOfClass:[JSONModel class]]) {
 
         //check if should export list of dictionaries
-        if ([property isKindOfClass:[NSArray class]]) {
+        if (p.type == [NSArray class]) {
 
             NSMutableArray* tempArray = [NSMutableArray arrayWithCapacity: [(NSArray*)value count] ];
             for (id<AbstractJSONModelProtocol> model in (NSArray*)value) {
@@ -541,7 +541,7 @@ static NSMutableDictionary* keyMappers = nil;
         }
         
         //check if should export dictionary of dictionaries
-        if ([property isKindOfClass:[NSDictionary class]]) {
+        if (p.type == [NSDictionary class]) {
             NSMutableDictionary* res = [NSMutableDictionary dictionary];
             for (NSString* key in [(NSDictionary*)value allKeys]) {
                 id<AbstractJSONModelProtocol> model = value[key];


### PR DESCRIPTION
When changing a JSONModel object back to a dictionary (via `toDictionary`), it will crash if there are custom JSONModel NSArray or NSDictionary properties due to the lack of there being a isEqualToString selector on either of these classes. 
