### PR TITLE
Fix document error. 

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -77,7 +77,7 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
    * For most classes the default initWithDictionary: inherited from JSONModel itself
    * should suffice, but developers have the option ot also overwrite it if needed.
    *
-   * @param d a dictionary holding JSON objects, to be imported in the model.
+   * @param dict a dictionary holding JSON objects, to be imported in the model.
    * @param err an error or NULL
    */
   -(instancetype)initWithDictionary:(NSDictionary*)dict error:(NSError**)err;

--- a/JSONModel/JSONModelNetworking/JSONAPI.h
+++ b/JSONModel/JSONModelNetworking/JSONAPI.h
@@ -59,7 +59,6 @@
  * @param path the URL path to add to the base API URL for this HTTP call
  * @param params the variables to pass to the API
  * @param completeBlock a JSONObjectBlock block to execute upon completion
- * @return the JSON response as desrialized object
  */
 +(void)getWithPath:(NSString*)path andParams:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
 
@@ -80,7 +79,6 @@
  * @param path the URL path to add to the base API URL for this HTTP call
  * @param params the variables to pass to the API
  * @param completeBlock a JSONObjectBlock block to execute upon completion
- * @return the JSON response as desrialized object
  */
 +(void)postWithPath:(NSString*)path andParams:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
 
@@ -101,7 +99,6 @@
  * @param method the HTTP method name; GET or POST only
  * @param args the list of arguments to pass to the API
  * @param completeBlock JSONObjectBlock to execute upon completion
- * @return the JSON response as desrialized object
  */
 +(void)rpcWithMethodName:(NSString*)method andArguments:(NSArray*)args completion:(JSONObjectBlock)completeBlock;
 

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.h
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.h
@@ -37,7 +37,7 @@ extern NSString* const kContentTypeWWWEncoded;
  * you receive back the initialized model (or nil) and an error (or nil)
  *
  * @param model the newly created JSONModel instance or nil
- * @param e JSONModelError or nil
+ * @param err JSONModelError or nil
  */
 typedef void (^JSONModelBlock)(JSONModel* model, JSONModelError* err);
 
@@ -158,7 +158,6 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  * Makes GET request to the given URL address and fetches a JSON response.
  * @param urlString the URL as a string
  * @param completeBlock JSONObjectBlock to execute upon completion
- * @return JSON compliant object or nil
  */
 +(void)getJSONFromURLWithString:(NSString*)urlString completion:(JSONObjectBlock)completeBlock;
 
@@ -167,7 +166,6 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  * @param urlString the URL as a string
  * @param params a dictionary of key / value pairs to be send as variables to the request
  * @param completeBlock JSONObjectBlock to execute upon completion
- * @return JSON compliant object or nil
  */
 +(void)getJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
 
@@ -179,7 +177,6 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  * @param urlString the URL as a string
  * @param params a dictionary of key / value pairs to be send as variables to the request
  * @param completeBlock JSONObjectBlock to execute upon completion
- * @return JSON compliant object or nil
  */
 +(void)postJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
 
@@ -188,7 +185,6 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  * @param urlString the URL as a string
  * @param bodyString the body of the POST request as a string
  * @param completeBlock JSONObjectBlock to execute upon completion
- * @return JSON compliant object or nil
  */
 +(void)postJSONFromURLWithString:(NSString*)urlString bodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock;
 
@@ -197,7 +193,6 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  * @param urlString the URL as a string
  * @param bodyData the body of the POST request as an NSData object
  * @param completeBlock JSONObjectBlock to execute upon completion
- * @return JSON compliant object or nil
  */
 +(void)postJSONFromURLWithString:(NSString*)urlString bodyData:(NSData*)bodyData completion:(JSONObjectBlock)completeBlock;
 


### PR DESCRIPTION
Remove redundant return, fix inconsistent parameter.

Also, I think 

``` plain
@property (strong, nonatomic) NSArray&lt;JSONModel, ConvertOnDemand&gt;* propertyName;
```

should write like

``` plain
`@property (strong, nonatomic) NSArray<JSONModel, ConvertOnDemand>* propertyName;`
```

or

```
@code
@property (strong, nonatomic) NSArray<JSONModel, ConvertOnDemand>* propertyName;
@endcode
```

But not test with appledoc yet.
