### PR TITLE
Use stringByAddingPercentEscapesUsingEncoding when creating NSURL from NSString 

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -149,7 +149,7 @@ extern BOOL isNull(id value)
 #pragma mark - string <-> url
 -(NSURL*)NSURLFromNSString:(NSString*)string
 {
-    return [NSURL URLWithString: string];
+    return [NSURL URLWithString: [string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 }
 
 -(NSString*)JSONObjectFromNSURL:(NSURL*)url


### PR DESCRIPTION
Consider an url like this, appearing in my JSON source: http://www.visir.is/jordan-slaer-milljard-af-villunni-sinni-|-myndir/article/2013130709873

This won't result in a valid NSURL. Doing stringByAddingPercentEscapesUsingEncoding seems like a smart thing to do in all cases.
