### PR TITLE
it is legal to include the header files into non-ARC files.

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -28,10 +28,6 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
 #define JMLog( s, ... )
 #endif
 /////////////////////////////////////////////////////////////////////////////////////////////
-#if !__has_feature(objc_arc)
-#error The JSONMOdel framework is ARC only, you can enable ARC on per file basis.
-#endif
-/////////////////////////////////////////////////////////////////////////////////////////////
 
 #pragma mark - Property Protocols
 /** 

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -14,6 +14,11 @@
 //
 // The MIT License in plain English: http://www.touch-code-magazine.com/JSONModel/MITLicense
 
+#if !__has_feature(objc_arc)
+#error The JSONMOdel framework is ARC only, you can enable ARC on per file basis.
+#endif
+
+
 #import <objc/runtime.h>
 
 #import "JSONModel.h"


### PR DESCRIPTION
As per Issue #63
