### PR TITLE
Add class method then subclass can specify which property is optional. T...

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -235,4 +235,9 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
  */
 +(void)setGlobalKeyMapper:(JSONKeyMapper*)globalKeyMapper;
 
+/**
+* Return value indicates whether one property is optional
+*/
++(BOOL)propertyIsOptional:(NSString*)propertyName;
+
 @end

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -501,7 +501,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
                 
                 p.isStandardJSONType = NO;
                 p.structName = propertyType;
-                
+
             }
             //the property must be a primitive
             else {
@@ -520,9 +520,13 @@ static JSONKeyMapper* globalKeyMapper = nil;
                                                    reason:[NSString stringWithFormat:@"Property type of %@.%@ is not supported by JSONModel.", self.class, p.name]
                                                  userInfo:nil];
                 }
-                
+
             }
-            
+
+            if([[self class] propertyIsOptional:[NSString stringWithCString:propertyName encoding:NSUTF8StringEncoding]]){
+                    p.isOptional = YES;
+            }
+
             //add the property object to the temp index
             [propertyIndex setValue:p forKey:p.name];
         }
@@ -974,4 +978,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
     globalKeyMapper = globalKeyMapperParam;
 }
 
++(BOOL)propertyIsOptional:(NSString*)propertyName{
+    return NO;
+}
 @end

--- a/JSONModelDemoTests/UnitTests/TestModels/OptionalPropModel.h
+++ b/JSONModelDemoTests/UnitTests/TestModels/OptionalPropModel.h
@@ -16,5 +16,9 @@
 /* optional property, not required in the JSON data */
 @property (strong, nonatomic) NSString<Optional>* notRequredProperty;
 
+/* optional struct property */
+@property (assign, nonatomic) CGPoint notRequiredPoint;
+
++(BOOL)propertyIsOptional:(NSString*)propertyName;
 
 @end

--- a/JSONModelDemoTests/UnitTests/TestModels/OptionalPropModel.m
+++ b/JSONModelDemoTests/UnitTests/TestModels/OptionalPropModel.m
@@ -10,4 +10,13 @@
 
 @implementation OptionalPropModel
 
++(BOOL)propertyIsOptional:(NSString*)propertyName{
+    if(![super propertyIsOptional:propertyName]){
+        if([@[@"notRequiredPoint"] containsObject:propertyName]){
+            return YES;
+        }
+    }
+    return NO;
+}
+
 @end


### PR DESCRIPTION
Now JSONModel use protocol to let the parser skips the field when no value provided. But this only useful on object field, not on structure or primitive fields.

I need to do this, I am using JSONModel as the main method of model serialization, and when the application upgraded and added some new properties, I have to mark those properties as optional to let the new app able to load some document created in earlier version.

Possible solution: Add one class method in JSONModel called optionalProperty which able to return whether one property is optional. Then sub class just overload it and provide the optional property check.

(Sorry for the spam, I closed the previous issue, a new issue created when I do a pull request.)
