### PR TITLE
Add a type-mismatch error to give more detail when the JSON is invalid because of the wrong type.

### DIFF
--- a/JSONModel/JSONModel/JSONModelError.h
+++ b/JSONModel/JSONModel/JSONModelError.h
@@ -38,6 +38,14 @@ extern NSString* const JSONModelErrorDomain;
  */
 extern NSString* const kJSONModelMissingKeys;
 
+/**
+ * If JSON input has a different type than expected by the model, check the
+ * userInfo dictionary of the JSONModelError instance you get back -
+ * under the kJSONModelTypeMismatch key you will find a description
+ * of the mismatched types.
+ */
+extern NSString* const kJSONModelTypeMismatch;
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 /**
  * Custom NSError subclass with shortcut methods for creating 
@@ -57,6 +65,12 @@ extern NSString* const kJSONModelMissingKeys;
  * @param keys a set of field names that were required, but not found in the input
  */
 +(id)errorInvalidDataWithMissingKeys:(NSSet*)keys;
+
+/**
+ * Creates a JSONModelError instance with code kJSONModelErrorInvalidData = 1
+ * @param A description of the type mismatch that was encountered.
+ */
++(id)errorInvalidDataWithTypeMismatch:(NSString*)mismatchDescription;
 
 /**
  * Creates a JSONModelError instance with code kJSONModelErrorBadResponse = 2

--- a/JSONModel/JSONModel/JSONModelError.m
+++ b/JSONModel/JSONModel/JSONModelError.m
@@ -18,6 +18,7 @@
 
 NSString* const JSONModelErrorDomain = @"JSONModelErrorDomain";
 NSString* const kJSONModelMissingKeys = @"kJSONModelMissingKeys";
+NSString* const kJSONModelTypeMismatch = @"kJSONModelTypeMismatch";
 
 @implementation JSONModelError
 
@@ -33,6 +34,13 @@ NSString* const kJSONModelMissingKeys = @"kJSONModelMissingKeys";
     return [JSONModelError errorWithDomain:JSONModelErrorDomain
                                       code:kJSONModelErrorInvalidData
                                   userInfo:@{NSLocalizedDescriptionKey:@"Invalid JSON data. Required JSON keys are missing from the input. Check the error user information.",kJSONModelMissingKeys:[keys allObjects]}];
+}
+
++(id)errorInvalidDataWithTypeMismatch:(NSString*)mismatchDescription
+{
+    return [JSONModelError errorWithDomain:JSONModelErrorDomain
+                                      code:kJSONModelErrorInvalidData
+                                  userInfo:@{NSLocalizedDescriptionKey:@"Invalid JSON data. The JSON type mismatches the expected type. Check the error user information.",kJSONModelTypeMismatch:mismatchDescription}];
 }
 
 +(id)errorBadResponse

--- a/JSONModelDemoTests/UnitTests/DataFiles/nestedDataWithTypeMismatchOnImages.json
+++ b/JSONModelDemoTests/UnitTests/DataFiles/nestedDataWithTypeMismatchOnImages.json
@@ -1,0 +1,15 @@
+{
+    "singleImage": {"idImage": 2, "name": "lake.jpg"},
+
+    "images": {
+		"x" : {"idImage": 1, "name": "house.jpg", "copyright":{"author":"Marin Todorov", "year":2012} },
+		"y" : {"idImage": 2, "name": "lake.jpg"},
+		"z" : {"idImage": 3, "name": "peak.jpg"}
+	},
+
+    "imagesObject": {
+        "image2": {"idImage": 2, "name": "lake.jpg"},
+        "image3": {"idImage": 3, "name": "peak.jpg"}
+    }
+
+}

--- a/JSONModelDemoTests/UnitTests/DataFiles/nestedDataWithTypeMismatchOnImagesObject.json
+++ b/JSONModelDemoTests/UnitTests/DataFiles/nestedDataWithTypeMismatchOnImagesObject.json
@@ -1,0 +1,15 @@
+{
+    "singleImage": {"idImage": 2, "name": "lake.jpg"},
+
+    "images": [
+               {"idImage": 1, "name": "house.jpg", "copyright":{"author":"Marin Todorov", "year":2012} },
+               {"idImage": 2, "name": "lake.jpg"},
+               {"idImage": 3, "name": "peak.jpg"}
+               ],
+
+    "imagesObject": [
+					 {"idImage": 2, "name": "lake.jpg"},
+					 {"idImage": 3, "name": "peak.jpg"}
+					 ]
+
+}

--- a/JSONModelDemoTests/UnitTests/SimpleDataErrorTests.m
+++ b/JSONModelDemoTests/UnitTests/SimpleDataErrorTests.m
@@ -33,6 +33,42 @@
     STAssertTrue([missingKeys[1] isEqualToString:@"longNumber"],@"missing field longNumber not found in missingKeys");
 }
 
+-(void)testTypeMismatchErrorImages
+{
+    NSString* filePath = [[NSBundle bundleForClass:[JSONModel class]].resourcePath stringByAppendingPathComponent:@"nestedDataWithTypeMismatchOnImages.json"];
+    NSString* jsonContents = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
+
+    STAssertNotNil(jsonContents, @"Can't fetch test data file contents.");
+
+    NSError* err;
+    NestedModel* p = [[NestedModel alloc] initWithString: jsonContents error:&err];
+    STAssertNil(p, @"Model is not nil, when input is invalid");
+    STAssertNotNil(err, @"No error when types mismatch.");
+
+    STAssertTrue(err.code == kJSONModelErrorInvalidData, @"Wrong error for type mismatch");
+    NSString* mismatchDescription = err.userInfo[kJSONModelTypeMismatch];
+    STAssertTrue(mismatchDescription, @"error does not have kJSONModelTypeMismatch key in user info");
+	STAssertTrue([mismatchDescription rangeOfString:@"'images'"].location != NSNotFound, @"error should mention that the 'images' property (expecting an Array) is mismatched.");
+}
+
+-(void)testTypeMismatchErrorImagesObject
+{
+    NSString* filePath = [[NSBundle bundleForClass:[JSONModel class]].resourcePath stringByAppendingPathComponent:@"nestedDataWithTypeMismatchOnImagesObject.json"];
+    NSString* jsonContents = [NSString stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
+
+    STAssertNotNil(jsonContents, @"Can't fetch test data file contents.");
+
+    NSError* err;
+    NestedModel* p = [[NestedModel alloc] initWithString: jsonContents error:&err];
+    STAssertNil(p, @"Model is not nil, when input is invalid");
+    STAssertNotNil(err, @"No error when types mismatch.");
+
+    STAssertTrue(err.code == kJSONModelErrorInvalidData, @"Wrong error for type mismatch");
+    NSString* mismatchDescription = err.userInfo[kJSONModelTypeMismatch];
+    STAssertTrue(mismatchDescription, @"error does not have kJSONModelTypeMismatch key in user info");
+	STAssertTrue([mismatchDescription rangeOfString:@"'imagesObject'"].location != NSNotFound, @"error should mention that the 'imagesObject' property (expecting a Dictionary) is mismatched.");
+}
+
 -(void)testBrokenJSON
 {
     NSString* jsonContents = @"{[1,23,4],\"123\":123,}";

--- a/JSONModelDemo_iOS.xcodeproj/project.pbxproj
+++ b/JSONModelDemo_iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		697852FD17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json in Resources */ = {isa = PBXBuildFile; fileRef = 697852FC17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json */; };
+		697852FF17D93547006BFCD0 /* nestedDataWithTypeMismatchOnImagesObject.json in Resources */ = {isa = PBXBuildFile; fileRef = 697852FE17D93546006BFCD0 /* nestedDataWithTypeMismatchOnImagesObject.json */; };
 		9C0D0240166E6BBF001EA645 /* KivaViewControllerNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C0D023E166E6BBF001EA645 /* KivaViewControllerNetworking.m */; };
 		9C0D0241166E6BBF001EA645 /* KivaViewControllerNetworking.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9C0D023F166E6BBF001EA645 /* KivaViewControllerNetworking.xib */; };
 		9C66DFA8168CEF420015CCDF /* ArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9C66DF60168CEF420015CCDF /* ArrayTests.m */; };
@@ -142,6 +144,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		697852FC17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nestedDataWithTypeMismatchOnImages.json; sourceTree = "<group>"; };
+		697852FE17D93546006BFCD0 /* nestedDataWithTypeMismatchOnImagesObject.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = nestedDataWithTypeMismatchOnImagesObject.json; sourceTree = "<group>"; };
 		9C0D023D166E6BBF001EA645 /* KivaViewControllerNetworking.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KivaViewControllerNetworking.h; sourceTree = "<group>"; };
 		9C0D023E166E6BBF001EA645 /* KivaViewControllerNetworking.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KivaViewControllerNetworking.m; sourceTree = "<group>"; };
 		9C0D023F166E6BBF001EA645 /* KivaViewControllerNetworking.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = KivaViewControllerNetworking.xib; sourceTree = "<group>"; };
@@ -414,6 +418,8 @@
 				9C66DF6B168CEF420015CCDF /* jsonTypes.json */,
 				9C66DF6C168CEF420015CCDF /* nestedData.json */,
 				9C66DF6D168CEF420015CCDF /* nestedDataWithErrors.json */,
+				697852FC17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json */,
+				697852FE17D93546006BFCD0 /* nestedDataWithTypeMismatchOnImagesObject.json */,
 				9C66DF6E168CEF420015CCDF /* post.json */,
 				9C66DF6F168CEF420015CCDF /* primitives.json */,
 				9C66DF70168CEF420015CCDF /* primitivesWithErrors.json */,
@@ -846,6 +852,8 @@
 				9C66DFB5168CEF420015CCDF /* withOptProp.json in Resources */,
 				9C66DFB6168CEF420015CCDF /* withoutOptProp.json in Resources */,
 				9CB1EE47172C1205004BAA07 /* specialPropertyName.json in Resources */,
+				697852FD17D934B5006BFCD0 /* nestedDataWithTypeMismatchOnImages.json in Resources */,
+				697852FF17D93547006BFCD0 /* nestedDataWithTypeMismatchOnImagesObject.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I had a property declared as `NSArray<MyProtocol>` instead of `NSDictionary<MyProtocol>` and JSONModel was not giving me any hints as to why the JSON was invalid (actually my model was wrong but I was blind to the error). It took ages to debug, so I added checking and more detailed error information in the userInfo when this type of error occurs. Now if anyone ever does this it will tell them exactly what the problem is. Includes two new unit tests to confirm the errors are generated correctly.
