### PR TITLE
[Req] Expose method for replacing all headers

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.h
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.h
@@ -131,6 +131,17 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  */
 +(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock;
 
+/**
+ * Makes a request to the given URL address and fetches a JSON response.
+ * @param urlString the URL as a string
+ * @param method the method of the request as a string
+ * @param params a dictionary of key / value pairs to be send as variables to the request
+ * @param bodyString the body of the POST request as a string
+ * @param headers the headers to set on the request - overrides those in +requestHeaders
+ * @param completeBlock JSONObjectBlock to execute upon completion
+ */
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock;
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - POST synchronious JSON calls
 

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.m
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.m
@@ -262,7 +262,17 @@ static NSString* requestContentType = nil;
 #pragma mark - Async network request
 +(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock
 {
-    NSDictionary* customHeaders = nil;
+    [self JSONFromURLWithString:urlString
+                         method:method
+                         params:params
+                   orBodyString:bodyString
+                        headers:nil
+                     completion:completeBlock];
+}
+
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock
+{
+    NSDictionary* customHeaders = headers;
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         


### PR DESCRIPTION
I'm finding it a pain to set up the headers on my requests.

It'd be useful if I could just replace the headers entirely, rather than having to do `[JSONHTTPClient.requestHeaders setDictionary:headers]`.

If you're open to this, I'll make a pull request.

Edit: corrected 'client' to 'JSONHTTPClient'
