### PR TITLE
[Req] Expose JSONFromURLWithString in JSONHTTPClient

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.h
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.h
@@ -121,6 +121,16 @@ typedef void (^JSONObjectBlock)(NSDictionary* json, JSONModelError* err);
  */
 +(void)getJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
 
+/**
+ * Makes a request to the given URL address and fetches a JSON response.
+ * @param urlString the URL as a string
+ * @param method the method of the request as a string
+ * @param params a dictionary of key / value pairs to be send as variables to the request
+ * @param bodyString the body of the POST request as a string
+ * @param completeBlock JSONObjectBlock to execute upon completion
+ */
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock;
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - POST synchronious JSON calls
 


### PR DESCRIPTION
It'd be super useful if this selector could be added to the JSONHTTPClient.h -

JSONFromURLWithString:method:params:orBodyString:completion:

Because I want to be able to request with any arbitrary method.

If you're open to this, I'll make a pull request.
