### PR TITLE
correction to null check

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -220,7 +220,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
         id jsonValue = [dict valueForKeyPath: jsonKeyPath];
         
         //check for Optional properties
-        if ((jsonValue==nil || [jsonValue isKindOfClass:NSNull.class]) && property.isOptional==YES) {
+        if (isNull(jsonValue) && property.isOptional==YES) {
             //skip this property, continue with next property
             continue;
         }


### PR DESCRIPTION
covers cases where the object is NSNull, but not nil.

NSNull != nil
