### PR TITLE
Use globalKeyMapper in serialization process too (toDictionary / toJSONString)

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -770,6 +770,9 @@ static JSONKeyMapper* globalKeyMapper = nil;
     //get the key mapper
     JSONKeyMapper* keyMapper = objc_getAssociatedObject(self.class, &kMapperObjectKey);
     
+    //if no custom mapper, check for a global mapper
+    if (keyMapper==nil && globalKeyMapper!=nil) keyMapper = globalKeyMapper;
+
     //loop over all properties
     for (JSONModelClassProperty* p in properties) {
         


### PR DESCRIPTION
I noticed that the globalKeyMapper wasn't used when turning models into JSON dictionaries or strings. 
This seems essential when using REST APIs and sending JSON body PUT or POST requests.
