### PR TITLE
Fix BOOL primitive type on 64-bit iOS platorms.

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -33,7 +33,8 @@ extern BOOL isNull(id value)
     if (self) {
         _primitivesNames = @{@"f":@"float", @"i":@"int", @"d":@"double", @"l":@"long", @"c":@"BOOL", @"s":@"short", @"q":@"long",
                              //and some famos aliases of primitive types
-                             @"I":@"NSInteger"};
+                             // BOOL is now "B" on iOS __LP64 builds
+                             @"I":@"NSInteger", @"B":@"BOOL"};
     }
     return self;
 }


### PR DESCRIPTION
On 64-bit iOS7 platforms bool is encoded as "B"
