### PR TITLE
corrected use of specific bit-length types to use universal types

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -944,7 +944,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
 			// Propagate the error, including the array index as the key-path component
 			if((err != nil) && (initErr != nil))
 			{
-				NSString* path = [NSString stringWithFormat:@"[%d]", list.count];
+				NSString* path = [NSString stringWithFormat:@"[%lu]", (unsigned long)list.count];
 				*err = [initErr errorByPrependingKeyPathComponent:path];
 			}
 			return nil;

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.m
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.m
@@ -29,13 +29,8 @@ NSString* const kContentTypeWWWEncoded   = @"application/x-www-form-urlencoded";
 /**
  * Defaults for HTTP requests
  */
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-static int defaultTextEncoding = NSUTF8StringEncoding;
-static int defaultCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-#else
-static long defaultTextEncoding = NSUTF8StringEncoding;
-static long defaultCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
-#endif
+static NSStringEncoding defaultTextEncoding = NSUTF8StringEncoding;
+static NSURLRequestCachePolicy defaultCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
 
 static int defaultTimeoutInSeconds = 60;
 
@@ -178,12 +173,7 @@ static NSString* requestContentType = nil;
         NSData* bodyData = [bodyString dataUsingEncoding:defaultTextEncoding];
         
         [request setHTTPBody: bodyData];
-#ifdef __IPHONE_OS_VERSION_MAX_ALLOWED
-        [request setValue:[NSString stringWithFormat:@"%i", [bodyData length]] forHTTPHeaderField:@"Content-Length"];
-#else
-        [request setValue:[NSString stringWithFormat:@"%ld", [bodyData length]] forHTTPHeaderField:@"Content-Length"];
-#endif
-        
+        [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)bodyData.length] forHTTPHeaderField:@"Content-Length"];
     }
     
     //prepare output


### PR DESCRIPTION
as per Apple's 64-bit conversion guide - https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Cocoa64BitGuide/ConvertingExistingApp/ConvertingExistingApp.html
