### PR TITLE
Add two methods to JSONModel+networking for asynchronously creating JSONModel objects.

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONModel+networking.h
+++ b/JSONModel/JSONModelNetworking/JSONModel+networking.h
@@ -37,4 +37,30 @@ typedef void (^JSONModelBlock)(id model, JSONModelError* err);
  */
 -(instancetype)initFromURLWithString:(NSString *)urlString completion:(JSONModelBlock)completeBlock;
 
+/**
+ * Asynchronously gets the contents of a URL and constructs a JSONModel object from the response.
+ * The constructed JSONModel object passed as the first parameter to the completion block will be of the same
+ * class as the receiver. So call this method on yourJSONModel sub-class rather than directly on JSONModel.
+ * @param	urlString		The absolute URL of the JSON resource, as a string
+ * @param	completeBlock	The block to be called upon completion.
+ *							JSONModelBlock type is defined as: void (^JSONModelBlock)(JSONModel* model, JSONModelError* err);
+ *							The first parameter is the initialized model (of the same JSONModel sub-class as the receiver) or nil if there was an error;
+ * 							The second parameter is the initialization error, if any.
+ */
++ (void)getModelFromURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock;
+
+/**
+ * Asynchronously posts a JSONModel object (as JSON) to a URL and constructs a JSONModel object from the response.
+ * The constructed JSONModel object passed as the first parameter to the completion block will be of the same
+ * class as the receiver. So call this method on yourJSONModel sub-class rather than directly on JSONModel.
+ * @param	post			A JSONModel object that will be converted to JSON and sent as the POST data to the HTTP request.
+ * @param	urlString		The absolute URL of the JSON resource, as a string
+ * @param	completeBlock	The block to be called upon completion.
+ *							JSONModelBlock type is defined as: void (^JSONModelBlock)(JSONModel* model, JSONModelError* err);
+ *							The first parameter is the initialized model (of the same JSONModel sub-class as the receiver) or nil if there was an error;
+ * 							The second parameter is the initialization error, if any.
+ */
++ (void)postModel:(JSONModel*)post toURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock;
+
+
 @end

--- a/JSONModel/JSONModelNetworking/JSONModel+networking.m
+++ b/JSONModel/JSONModelNetworking/JSONModel+networking.m
@@ -61,4 +61,49 @@ BOOL _isLoading;
     return self;
 }
 
++ (void)getModelFromURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock
+{
+	[JSONHTTPClient getJSONFromURLWithString:urlString
+								  completion:^(NSDictionary* jsonDict, JSONModelError* err)
+	{
+		JSONModel* model = nil;
+
+		if(err == nil)
+		{
+			model = [[self alloc] initWithDictionary:jsonDict error:&err];
+		}
+
+		if(completeBlock != nil)
+		{
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
+				completeBlock(model, err);
+			});
+		}
+    }];
+}
+
++ (void)postModel:(JSONModel*)post toURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock
+{
+	[JSONHTTPClient postJSONFromURLWithString:urlString
+								   bodyString:[post toJSONString]
+								   completion:^(NSDictionary* jsonDict, JSONModelError* err)
+	{
+		JSONModel* model = nil;
+
+		if(err == nil)
+		{
+			model = [[self alloc] initWithDictionary:jsonDict error:&err];
+		}
+
+		if(completeBlock != nil)
+		{
+			dispatch_async(dispatch_get_main_queue(), ^
+			{
+				completeBlock(model, err);
+			});
+		}
+	}];
+}
+
 @end


### PR DESCRIPTION
One from a GET request and one from a POST (with another JSONModel object).
