### PR TITLE
Added propertyIsIgnored: overridable method

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -254,4 +254,13 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
  */
 +(BOOL)propertyIsOptional:(NSString*)propertyName;
 
+/**
+ * Indicates whether the property with the given name is Ignored.
+ * To have a model with all of its properties being Ignored just return YES.
+ * This method returns by default NO, since the default behaviour is to have all properties required.
+ * @param propertyName the name of the property
+ * @return a BOOL result indicating whether the property is ignored
+ */
++(BOOL)propertyIsIgnored:(NSString*)propertyName;
+
 @end

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -546,6 +546,10 @@ static JSONKeyMapper* globalKeyMapper = nil;
                     p.isOptional = YES;
             }
 
+            if([[self class] propertyIsIgnored:[NSString stringWithCString:propertyName encoding:NSUTF8StringEncoding]]){
+                    p = nil;
+            }
+
             //add the property object to the temp index
             if (p) {
                 [propertyIndex setValue:p forKey:p.name];
@@ -1063,6 +1067,11 @@ static JSONKeyMapper* globalKeyMapper = nil;
 }
 
 +(BOOL)propertyIsOptional:(NSString*)propertyName
+{
+    return NO;
+}
+
++(BOOL)propertyIsIgnored:(NSString *)propertyName
 {
     return NO;
 }


### PR DESCRIPTION
Can be used in lieu of the <Ignore> protocol for primitive types where protocols cannot be used.
