### PR TITLE
Added ability to pass NSData directly into POSTs

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.h
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.h
@@ -142,6 +142,17 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  */
 +(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock;
 
+/**
+ * Makes a request to the given URL address and fetches a JSON response.
+ * @param urlString the URL as a string
+ * @param method the method of the request as a string
+ * @param params a dictionary of key / value pairs to be send as variables to the request
+ * @param bodyData the body of the POST request as raw binary data
+ * @param headers the headers to set on the request - overrides those in +requestHeaders
+ * @param completeBlock JSONObjectBlock to execute upon completion
+ */
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary *)params orBodyData:(NSData*)bodyData headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock;
+
 /////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - POST synchronious JSON calls
 


### PR DESCRIPTION
In my implementations, I have found myself converting from NSData into NSString so it can be used with JSONModel when JSONModel just ends up turning it back into NSData later on.

NSData containing null characters cannot be converted into NSStrings because C-strings use the null character to signal the end of the string.

This addresses inefficiency when converting back-and-forth, but also makes it possible to POST data containing null characters.
