### PR TITLE
Corrected NSURL transformation

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -164,7 +164,7 @@ extern BOOL isNull(id value)
 #pragma mark - string <-> url
 -(NSURL*)NSURLFromNSString:(NSString*)string
 {
-    return [NSURL URLWithString: [string stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+    return [NSURL URLWithString:string];
 }
 
 -(NSString*)JSONObjectFromNSURL:(NSURL*)url


### PR DESCRIPTION
The original code was causing URLs to be double encoded

URLs in JSON should be assumed to already be encoded correctly
