### PR TITLE
Fix ignored pragma in JSONAPI implementation

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONAPI.m
+++ b/JSONModel/JSONModelNetworking/JSONAPI.m
@@ -147,6 +147,6 @@ static long jsonRpcId = 0;
 
 @end
 
-#pragma - helper rpc error model class implementation
+#pragma mark - helper rpc error model class implementation
 @implementation JSONAPIRPCErrorModel
 @end


### PR DESCRIPTION
At the bottom of `JSONAPI.m` there was a pragma being ignored. This changes
the `#pragma -` to `#pragma mark -` so it is properly picked up.
