### PR TITLE
Fix: force date parser to use military hours

### DIFF
--- a/JSONModel/JSONModelTransformations/JSONValueTransformer.m
+++ b/JSONModel/JSONModelTransformations/JSONValueTransformer.m
@@ -26,6 +26,8 @@ extern BOOL isNull(id value)
     return NO;
 }
 
+static NSDateFormatter *_dateFormatter;
+
 @implementation JSONValueTransformer
 
 -(id)init
@@ -205,21 +207,26 @@ extern BOOL isNull(id value)
 }
 
 #pragma mark - string <-> date
+- (void) initDateFormatter
+{
+    _dateFormatter = [[NSDateFormatter alloc] init];
+    [_dateFormatter setDateFormat:@"yyyy-MM-dd'T'HHmmssZZZZ"];
+    [_dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_GB"]];    //this will force to parse datetimes in military format
+}
+
 -(NSDate*)__NSDateFromNSString:(NSString*)string
 {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    //avoid multiple allocations when parsing dates by using a static reference
+    if (!_dateFormatter) [self initDateFormatter];
     string = [string stringByReplacingOccurrencesOfString:@":" withString:@""]; // this is such an ugly code, is this the only way?
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HHmmssZZZZ"];
-    
-    return [dateFormatter dateFromString: string];
+    return [_dateFormatter dateFromString: string];
 }
 
 -(NSString*)__JSONObjectFromNSDate:(NSDate*)date
 {
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZZZ"];
-    
-    return [dateFormatter stringFromDate:date];
+    //avoid multiple allocations when parsing dates by using a static reference
+    if (!_dateFormatter) [self initDateFormatter];
+    return [_dateFormatter stringFromDate:date];
 }
 
 #pragma mark - hidden transform for empty dictionaries


### PR DESCRIPTION
This fixes an issue that occurs when device is set to use am/pm hour format and trying to parse iso 8601 datetimes, on which cases it retrieves nil.
Also dateFormatter is stored in static reference to avoid multiple allocations when parsing, improving performance.
