### PR TITLE
Deprecate networking support

### DIFF
--- a/JSONModel/JSONModelNetworking/JSONAPI.h
+++ b/JSONModel/JSONModelNetworking/JSONAPI.h
@@ -24,7 +24,7 @@
  * and facilitates making requests to the same web host. Also features helper
  * method for making calls to a JSON RPC service
  */
-@interface JSONAPI : NSObject
+DEPRECATED_ATTRIBUTE @interface JSONAPI : NSObject
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -33,14 +33,14 @@
  * Sets the API url
  * @param base the API url as a string
  */
-+(void)setAPIBaseURLWithString:(NSString*)base;
++(void)setAPIBaseURLWithString:(NSString*)base DEPRECATED_ATTRIBUTE;
 
 /**
  * Sets the default content type for the requests/responses
  * @param ctype The content-type as a string. Some possible types, 
  * depending on the service: application/json, text/json, x-application/javascript, etc.
  */
-+(void)setContentType:(NSString*)ctype;
++(void)setContentType:(NSString*)ctype DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -51,7 +51,7 @@
  * @param params the variables to pass to the API
  * @param completeBlock a JSONObjectBlock block to execute upon completion
  */
-+(void)getWithPath:(NSString*)path andParams:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
++(void)getWithPath:(NSString*)path andParams:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -62,7 +62,7 @@
  * @param params the variables to pass to the API
  * @param completeBlock a JSONObjectBlock block to execute upon completion
  */
-+(void)postWithPath:(NSString*)path andParams:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
++(void)postWithPath:(NSString*)path andParams:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -73,7 +73,7 @@
  * @param args the list of arguments to pass to the API
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)rpcWithMethodName:(NSString*)method andArguments:(NSArray*)args completion:(JSONObjectBlock)completeBlock;
++(void)rpcWithMethodName:(NSString*)method andArguments:(NSArray*)args completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /** @name JSON RPC (2.0) request method */
 /**
@@ -83,7 +83,7 @@
  * depending whether you're using named or unnamed parameters
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)rpc2WithMethodName:(NSString*)method andParams:(id)params completion:(JSONObjectBlock)completeBlock;
++(void)rpc2WithMethodName:(NSString*)method andParams:(id)params completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/JSONModel/JSONModelNetworking/JSONAPI.m
+++ b/JSONModel/JSONModelNetworking/JSONAPI.m
@@ -25,7 +25,11 @@
 
 #pragma mark - static variables
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static JSONAPI* sharedInstance = nil;
+#pragma GCC diagnostic pop
+
 static long jsonRpcId = 0;
 
 #pragma mark - JSONAPI() private interface
@@ -44,7 +48,10 @@ static long jsonRpcId = 0;
 {
     static dispatch_once_t once;
     dispatch_once(&once, ^{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         sharedInstance = [[JSONAPI alloc] init];
+#pragma GCC diagnostic pop
     });
 }
 

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.h
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.h
@@ -21,15 +21,15 @@
 /**
  * HTTP Request methods
  */
-extern NSString* const kHTTPMethodGET;
-extern NSString* const kHTTPMethodPOST;
+extern NSString* const kHTTPMethodGET DEPRECATED_ATTRIBUTE;
+extern NSString* const kHTTPMethodPOST DEPRECATED_ATTRIBUTE;
 
 /**
  * Content-type strings
  */
-extern NSString* const kContentTypeAutomatic;
-extern NSString* const kContentTypeJSON;
-extern NSString* const kContentTypeWWWEncoded;
+extern NSString* const kContentTypeAutomatic DEPRECATED_ATTRIBUTE;
+extern NSString* const kContentTypeJSON DEPRECATED_ATTRIBUTE;
+extern NSString* const kContentTypeWWWEncoded DEPRECATED_ATTRIBUTE;
 
 /**
  * A block type to handle incoming JSON object and an error. 
@@ -39,7 +39,7 @@ extern NSString* const kContentTypeWWWEncoded;
  * @param json object derived from a JSON string
  * @param err JSONModelError or nil
  */
-typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
+typedef void (^JSONObjectBlock)(id json, JSONModelError* err) DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - configuration methods
@@ -48,7 +48,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @discussion A very thin HTTP client that can do GET and POST HTTP requests.
  * It fetches only JSON data and also deserializes it using NSJSONSerialization.
  */
-@interface JSONHTTPClient : NSObject
+DEPRECATED_ATTRIBUTE @interface JSONHTTPClient : NSObject
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -63,27 +63,27 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * headers[@"APIToken"] = @"MySecretTokenValue";
  * </pre>
  */
-+(NSMutableDictionary*)requestHeaders;
++(NSMutableDictionary*)requestHeaders DEPRECATED_ATTRIBUTE;
 
 /**
  * Sets the default encoding of the request body.
  * See NSStringEncoding for a list of supported encodings
  * @param encoding text encoding constant
  */
-+(void)setDefaultTextEncoding:(NSStringEncoding)encoding;
++(void)setDefaultTextEncoding:(NSStringEncoding)encoding DEPRECATED_ATTRIBUTE;
 
 /**
  * Sets the policies for caching HTTP data
  * See NSURLRequestCachePolicy for a list of the pre-defined policies
  * @param policy the caching policy
  */
-+(void)setCachingPolicy:(NSURLRequestCachePolicy)policy;
++(void)setCachingPolicy:(NSURLRequestCachePolicy)policy DEPRECATED_ATTRIBUTE;
 
 /**
  * Sets the timeout for network calls
  * @param seconds the amount of seconds to wait before considering the call failed
  */
-+(void)setTimeoutInSeconds:(int)seconds;
++(void)setTimeoutInSeconds:(int)seconds DEPRECATED_ATTRIBUTE;
 
 /**
  * A method to set the default content type of the request body
@@ -91,7 +91,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * which checks the body request and decides between "application/json"
  * and "application/x-www-form-urlencoded"
  */
-+(void)setRequestContentType:(NSString*)contentTypeString;
++(void)setRequestContentType:(NSString*)contentTypeString DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - GET asynchronous JSON calls
@@ -102,7 +102,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param urlString the URL as a string
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)getJSONFromURLWithString:(NSString*)urlString completion:(JSONObjectBlock)completeBlock;
++(void)getJSONFromURLWithString:(NSString*)urlString completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Makes GET request to the given URL address and fetches a JSON response. Sends the params as a query string variables.
@@ -110,7 +110,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param params a dictionary of key / value pairs to be send as variables to the request
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)getJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
++(void)getJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Makes a request to the given URL address and fetches a JSON response.
@@ -120,7 +120,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param bodyString the body of the POST request as a string
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock;
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Makes a request to the given URL address and fetches a JSON response.
@@ -131,7 +131,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param headers the headers to set on the request - overrides those in +requestHeaders
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock;
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary*)params orBodyString:(NSString*)bodyString headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Makes a request to the given URL address and fetches a JSON response.
@@ -142,7 +142,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param headers the headers to set on the request - overrides those in +requestHeaders
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary *)params orBodyData:(NSData*)bodyData headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock;
++(void)JSONFromURLWithString:(NSString*)urlString method:(NSString*)method params:(NSDictionary *)params orBodyData:(NSData*)bodyData headers:(NSDictionary*)headers completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark - POST asynchronous JSON calls
@@ -153,7 +153,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param params a dictionary of key / value pairs to be send as variables to the request
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)postJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock;
++(void)postJSONFromURLWithString:(NSString*)urlString params:(NSDictionary*)params completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Makes POST request to the given URL address and fetches a JSON response. Sends the bodyString param as the POST request body.
@@ -161,7 +161,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param bodyString the body of the POST request as a string
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)postJSONFromURLWithString:(NSString*)urlString bodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock;
++(void)postJSONFromURLWithString:(NSString*)urlString bodyString:(NSString*)bodyString completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Makes POST request to the given URL address and fetches a JSON response. Sends the bodyString param as the POST request body.
@@ -169,7 +169,7 @@ typedef void (^JSONObjectBlock)(id json, JSONModelError* err);
  * @param bodyData the body of the POST request as an NSData object
  * @param completeBlock JSONObjectBlock to execute upon completion
  */
-+(void)postJSONFromURLWithString:(NSString*)urlString bodyData:(NSData*)bodyData completion:(JSONObjectBlock)completeBlock;
++(void)postJSONFromURLWithString:(NSString*)urlString bodyData:(NSData*)bodyData completion:(JSONObjectBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 
 @end

--- a/JSONModel/JSONModelNetworking/JSONHTTPClient.m
+++ b/JSONModel/JSONModelNetworking/JSONHTTPClient.m
@@ -55,7 +55,11 @@ static NSString* requestContentType = nil;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         requestHeaders = [NSMutableDictionary dictionary];
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         requestContentType = kContentTypeAutomatic;
+#pragma GCC diagnostic pop
     });
 }
 

--- a/JSONModel/JSONModelNetworking/JSONModel+networking.h
+++ b/JSONModel/JSONModelNetworking/JSONModel+networking.h
@@ -17,7 +17,7 @@
 #import "JSONModel.h"
 #import "JSONHTTPClient.h"
 
-typedef void (^JSONModelBlock)(id model, JSONModelError* err);
+typedef void (^JSONModelBlock)(id model, JSONModelError* err) DEPRECATED_ATTRIBUTE;
 
 /**
  * The JSONModel(networking) class category adds networking to JSONModel.
@@ -27,7 +27,7 @@ typedef void (^JSONModelBlock)(id model, JSONModelError* err);
  */
 @interface JSONModel(Networking)
 
-@property (assign, nonatomic) BOOL isLoading;
+@property (assign, nonatomic) BOOL isLoading DEPRECATED_ATTRIBUTE;
 /** @name Asynchronously create a model over the network */
 /**
  * Asynchronously create a model over the network. Create a new model instance and initialize it with the JSON fetched from the given URL
@@ -35,7 +35,7 @@ typedef void (^JSONModelBlock)(id model, JSONModelError* err);
  * @param completeBlock JSONModelBlock executed upon completion. The JSONModelBlock type is defined as: void (^JSONModelBlock)(JSONModel* model, JSONModelError* e); the first parameter is the initialized model or nil, 
  * and second parameter holds the model initialization error, if any
  */
--(instancetype)initFromURLWithString:(NSString *)urlString completion:(JSONModelBlock)completeBlock;
+-(instancetype)initFromURLWithString:(NSString *)urlString completion:(JSONModelBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Asynchronously gets the contents of a URL and constructs a JSONModel object from the response.
@@ -47,7 +47,7 @@ typedef void (^JSONModelBlock)(id model, JSONModelError* err);
  *							The first parameter is the initialized model (of the same JSONModel sub-class as the receiver) or nil if there was an error;
  * 							The second parameter is the initialization error, if any.
  */
-+ (void)getModelFromURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock;
++ (void)getModelFromURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 /**
  * Asynchronously posts a JSONModel object (as JSON) to a URL and constructs a JSONModel object from the response.
@@ -60,7 +60,7 @@ typedef void (^JSONModelBlock)(id model, JSONModelError* err);
  *							The first parameter is the initialized model (of the same JSONModel sub-class as the receiver) or nil if there was an error;
  * 							The second parameter is the initialization error, if any.
  */
-+ (void)postModel:(JSONModel*)post toURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock;
++ (void)postModel:(JSONModel*)post toURLWithString:(NSString*)urlString completion:(JSONModelBlock)completeBlock DEPRECATED_ATTRIBUTE;
 
 
 @end

--- a/JSONModelDemoTests/UnitTests/HTTPClientSuite.m
+++ b/JSONModelDemoTests/UnitTests/HTTPClientSuite.m
@@ -15,6 +15,8 @@
 #import "MockNSURLConnection.h"
 #import "MTTestSemaphor.h"
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation HTTPClientSuite
 {
     NSString* jsonContents;

--- a/JSONModelDemoTests/UnitTests/InitFromWebTests.m
+++ b/JSONModelDemoTests/UnitTests/InitFromWebTests.m
@@ -13,6 +13,8 @@
 
 #import "NestedModel.h"
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation InitFromWebTests
 {
     NSString* jsonContents;

--- a/JSONModelDemoTests/UnitTests/JSONAPITests.m
+++ b/JSONModelDemoTests/UnitTests/JSONAPITests.m
@@ -13,6 +13,8 @@
 #import "JSONModelLib.h"
 #import "RpcRequestModel.h"
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation JSONAPITests
 
 -(void)testBaseURL

--- a/JSONModelDemo_iOS/KivaViewController.m
+++ b/JSONModelDemo_iOS/KivaViewController.m
@@ -30,7 +30,10 @@
     self.title = @"Kiva.org latest loans";
     [HUD showUIBlockingIndicatorWithText:@"Fetching JSON"];
     
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     [JSONHTTPClient getJSONFromURLWithString:@"https://api.kivaws.org/v1/loans/search.json"
+#pragma GCC diagnostic pop
                                       params:@{@"status":@"fundraising"}
                                   completion:^(NSDictionary *json, JSONModelError *err) {
                                                                             

--- a/JSONModelDemo_iOS/KivaViewControllerNetworking.m
+++ b/JSONModelDemo_iOS/KivaViewControllerNetworking.m
@@ -29,7 +29,10 @@
 
     [HUD showUIBlockingIndicatorWithText:@"Fetching JSON"];
     
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     feed = [[KivaFeed alloc] initFromURLWithString:@"http://api.kivaws.org/v1/loans/search.json?status=fundraising"
+#pragma GCC diagnostic pop
                                         completion:^(JSONModel *model, JSONModelError* e) {
         
         [HUD hideUIBlockingIndicator];

--- a/JSONModelOSX/ViewController.m
+++ b/JSONModelOSX/ViewController.m
@@ -131,7 +131,10 @@ enum kServices {
     currentService = kServiceKiva;
     [self setLoaderVisible:YES];
     
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     kiva = [[KivaFeed alloc] initFromURLWithString:@"https://api.kivaws.org/v1/loans/search.json?status=fundraising"
+#pragma GCC diagnostic pop
             completion:^(JSONModel *model, JSONModelError *e) {
                 
                 [table reloadData];
@@ -150,7 +153,10 @@ enum kServices {
     currentService = kServiceGithub;
     [self setLoaderVisible:YES];
     
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     user = [[GitHubUserModel alloc] initFromURLWithString:@"https://api.github.com/users/icanzilb"
+#pragma GCC diagnostic pop
                                                completion:^(JSONModel *model, JSONModelError *e) {
 
                                                    items = @[user.login, user.html_url, user.company, user.name, user.blog];


### PR DESCRIPTION
As discussed in #497. This deprecates all the JSONModelNetworking code.