### PR TITLE
Deprecate global key mapper

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -295,7 +295,7 @@ __attribute__ ((deprecated))
  *
  * Lookup JSONKeyMapper docs for more details.
  */
-+(void)setGlobalKeyMapper:(JSONKeyMapper*)globalKeyMapper;
++(void)setGlobalKeyMapper:(JSONKeyMapper*)globalKeyMapper DEPRECATED_MSG_ATTRIBUTE("override +keyMapper in a base model class instead");
 
 /**
  * Indicates whether the property with the given name is Optional.

--- a/JSONModelDemoTests/UnitTests/KeyMappingTests.m
+++ b/JSONModelDemoTests/UnitTests/KeyMappingTests.m
@@ -14,6 +14,8 @@
 #import "ModelForUpperCaseMapper.h"
 #import "RenamedPropertyModel.h"
 
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #pragma mark - TestModel class
 @interface TestModel: JSONModel
 


### PR DESCRIPTION
As discussed in #497. This deprecates the `+setGlobalKeyMapper:` method.

This change needs a bit more consideration & discussion before merging I think, but it's available if we do decide to make the change.