### PR TITLE
Replaced icanzilb for JSONModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ If you like JSONModel and use it, could you please:
 
 ---
 
-![JSONModel for iOS and OSX](h
-ttp://jsonmodel.com/img/jsonmodel_logolike.png)
+![JSONModel for iOS and OSX](http://jsonmodel.com/img/jsonmodel_logolike.png)
 
 JSONModel is a library, which allows rapid creation of smart data models. You can use it in your iOS or OSX apps.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ If you like JSONModel and use it, could you please:
 
 ---
 
-![JSONModel for iOS and OSX](http://jsonmodel.com/img/jsonmodel_logolike.png)
+![JSONModel for iOS and OSX](h
+ttp://jsonmodel.com/img/jsonmodel_logolike.png)
 
 JSONModel is a library, which allows rapid creation of smart data models. You can use it in your iOS or OSX apps.
 
@@ -33,7 +34,7 @@ Adding JSONModel to your project
 
 #### Get it as: 1) source files
 
-1. Download the JSONModel repository as a [zip file](https://github.com/icanzilb/JSONModel/archive/master.zip) or clone it
+1. Download the JSONModel repository as a [zip file](https://github.com/JSONModel/JSONModel/archive/master.zip) or clone it
 2. Copy the JSONModel sub-folder into your Xcode project
 3. Link your app to SystemConfiguration.framework
 
@@ -51,7 +52,7 @@ If you want to read more about CocoaPods, have a look at [this short tutorial](h
 In your project's **Cartfile** add the JSONModel:
 
 ```ruby
-github "icanzilb/JSONModel"
+github "JSONModel/JSONModel"
 ```
 
 #### Docs
@@ -521,9 +522,9 @@ Misc
 Author: [Marin Todorov](http://www.touch-code-magazine.com)
 
 Contributors: Christian Hoffmann, Mark Joslin, Julien Vignali, Symvaro GmbH, BB9z.
-Also everyone who did successful [pull requests](https://github.com/icanzilb/JSONModel/graphs/contributors).
+Also everyone who did successful [pull requests](https://github.com/JSONModel/JSONModel/graphs/contributors).
 
-Change log : [https://github.com/icanzilb/JSONModel/blob/master/Changelog.md](https://github.com/icanzilb/JSONModel/blob/master/Changelog.md)
+Change log : [https://github.com/JSONModel/JSONModel/blob/master/Changelog.md](https://github.com/JSONModel/JSONModel/blob/master/Changelog.md)
 
 Utility to generate JSONModel classes from JSON data: https://github.com/dofork/json2object
 


### PR DESCRIPTION
References to old `icanzilb` repo were changed to `JSONModel`