### PR TITLE
Use NSSecureCoding instead of NSCoding when possible

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -1386,7 +1386,13 @@ static JSONKeyMapper* globalKeyMapper = nil;
 
 -(instancetype)initWithCoder:(NSCoder *)decoder
 {
-    NSString* json = [decoder decodeObjectForKey:@"json"];
+    NSString* json;
+    
+    if ([decoder respondsToSelector:@selector(decodeObjectOfClass:forKey:)]) {
+        json = [decoder decodeObjectOfClass:[NSString class] forKey:@"json"];
+    } else {
+        json = [decoder decodeObjectForKey:@"json"];
+    }
 
     JSONModelError *error = nil;
     self = [self initWithString:json error:&error];


### PR DESCRIPTION
Hey,

This is just a tiny improvement. We should use more secure way how to decode object when it's available.

Vojta