### PR TITLE
Keep optional nil values in the JSON.

### DIFF
--- a/JSONModel/JSONModel/JSONModel.h
+++ b/JSONModel/JSONModel/JSONModel.h
@@ -252,6 +252,15 @@ DEPRECATED_ATTRIBUTE
 + (BOOL)propertyIsIgnored:(NSString *)propertyName;
 
 /**
+ * By default the optional properties are removed from the JSON if there is no value assigned (== nil).
+ * In same cases optional values could mean the value can be null, but shall be presented in the JSON.
+ * To keep the nil/null values in the model just return YES.
+ * This method returns by default NO.
+ * @return a BOOL result indicating whether the nil/null values are presented
+ */
++ (BOOL)keepOptionalNilValues;
+
+/**
  * Indicates the class used for the elements of a collection property.
  * Rather than using:
  *     @property (strong) NSArray <MyType> *things;

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -953,7 +953,11 @@ static JSONKeyMapper* globalKeyMapper = nil;
 
             if (value == nil)
             {
-                [tempDictionary removeObjectForKey:keyPath];
+                if ([[self class] keepOptionalNilValues] ){
+                    [tempDictionary setValue:[NSNull null] forKeyPath:keyPath];
+                } else {
+                    [tempDictionary removeObjectForKey:keyPath];
+                }
             }
             else
             {
@@ -1322,6 +1326,10 @@ static JSONKeyMapper* globalKeyMapper = nil;
 
 +(BOOL)propertyIsIgnored:(NSString *)propertyName
 {
+    return NO;
+}
+
++(BOOL) keepOptionalNilValues {
     return NO;
 }
 


### PR DESCRIPTION
In same cases optional values could mean the value can be null, but shall be presented in the JSON.
