### PR TITLE
add optional switch for primitive type

### DIFF
--- a/JSONModel.xcodeproj/project.pbxproj
+++ b/JSONModel.xcodeproj/project.pbxproj
@@ -58,6 +58,8 @@
 		01D68A4E1E421BE300CFE82F /* JSONValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 92C9BC7A1B19A5B600D79B06 /* JSONValueTransformer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		01D68A4F1E421BE900CFE82F /* JSONValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BC7B1B19A5B600D79B06 /* JSONValueTransformer.m */; };
 		01D68A501E421BE900CFE82F /* JSONValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BC7B1B19A5B600D79B06 /* JSONValueTransformer.m */; };
+		1FCD35411E891E1B00399CE0 /* JSONModel+Primitive.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FCD353F1E891E1B00399CE0 /* JSONModel+Primitive.h */; };
+		1FCD35421E891E1B00399CE0 /* JSONModel+Primitive.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FCD35401E891E1B00399CE0 /* JSONModel+Primitive.m */; };
 		92C9BC7C1B19A5B600D79B06 /* JSONModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 92C9BC641B19A5B600D79B06 /* JSONModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		92C9BC7D1B19A5B600D79B06 /* JSONModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 92C9BC651B19A5B600D79B06 /* JSONModel.m */; };
 		92C9BC801B19A5B600D79B06 /* JSONModelClassProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 92C9BC681B19A5B600D79B06 /* JSONModelClassProperty.h */; };
@@ -84,6 +86,9 @@
 		01D68A1D1E421A8500CFE82F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		01D68A271E421AC100CFE82F /* JSONModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSONModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		01D68A2A1E421AC100CFE82F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1FCD353F1E891E1B00399CE0 /* JSONModel+Primitive.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JSONModel+Primitive.h"; sourceTree = "<group>"; };
+		1FCD35401E891E1B00399CE0 /* JSONModel+Primitive.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "JSONModel+Primitive.m"; sourceTree = "<group>"; };
+		1FCD35431E89264600399CE0 /* JSONModelPrimitiveProtocal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSONModelPrimitiveProtocal.h; sourceTree = "<group>"; };
 		92C9BC3D1B19A51100D79B06 /* JSONModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSONModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		92C9BC411B19A51100D79B06 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		92C9BC641B19A5B600D79B06 /* JSONModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONModel.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
@@ -207,6 +212,9 @@
 				92C9BC691B19A5B600D79B06 /* JSONModelClassProperty.m */,
 				92C9BC6A1B19A5B600D79B06 /* JSONModelError.h */,
 				92C9BC6B1B19A5B600D79B06 /* JSONModelError.m */,
+				1FCD353F1E891E1B00399CE0 /* JSONModel+Primitive.h */,
+				1FCD35401E891E1B00399CE0 /* JSONModel+Primitive.m */,
+				1FCD35431E89264600399CE0 /* JSONModelPrimitiveProtocal.h */,
 			);
 			path = JSONModel;
 			sourceTree = "<group>";
@@ -296,6 +304,7 @@
 				92C9BC801B19A5B600D79B06 /* JSONModelClassProperty.h in Headers */,
 				92C9BC871B19A5B600D79B06 /* JSONAPI.h in Headers */,
 				92C9BC7C1B19A5B600D79B06 /* JSONModel.h in Headers */,
+				1FCD35411E891E1B00399CE0 /* JSONModel+Primitive.h in Headers */,
 				92C9BC821B19A5B600D79B06 /* JSONModelError.h in Headers */,
 				92C9BC891B19A5B600D79B06 /* JSONHTTPClient.h in Headers */,
 				92C9BC8D1B19A5B600D79B06 /* JSONKeyMapper.h in Headers */,
@@ -507,6 +516,7 @@
 				92C9BC8A1B19A5B600D79B06 /* JSONHTTPClient.m in Sources */,
 				92C9BC831B19A5B600D79B06 /* JSONModelError.m in Sources */,
 				92C9BC901B19A5B600D79B06 /* JSONValueTransformer.m in Sources */,
+				1FCD35421E891E1B00399CE0 /* JSONModel+Primitive.m in Sources */,
 				92C9BC8E1B19A5B600D79B06 /* JSONKeyMapper.m in Sources */,
 				92C9BC881B19A5B600D79B06 /* JSONAPI.m in Sources */,
 				92C9BC7D1B19A5B600D79B06 /* JSONModel.m in Sources */,

--- a/JSONModel/JSONModel/JSONModel+Primitive.h
+++ b/JSONModel/JSONModel/JSONModel+Primitive.h
@@ -1,0 +1,22 @@
+//
+//  JSONModel+Primitive.h
+//  JSONModel
+//
+
+#import "JSONModel.h"
+
+@interface JSONModel (Primitive)
+
+/**
+ *  For a non-primitive type object, if declaring "<Optioanl>" for it, it can be missing in the input data,
+ *  But there's no 'isOptional' switch for a primitive type data, such as int, long , float, double, etc.
+ *  Primitive type is always considered as a set of the required keys for the model. To solve the problem,
+ *  method 'allowPrimitiveTypeAsOptioanl' is a good way to handle this problem. It take the role as the same
+ *  as JSONModelClassProperty's 'isOptional' property for a primitive type.
+ *  Implementing JSONModelPrimitiveProtocol in model could determine primitive type(s) is optioanal or required.
+ */
+- (BOOL)allowPrimitiveTypeAsOptioanl;
+
+@end
+
+

--- a/JSONModel/JSONModel/JSONModel+Primitive.m
+++ b/JSONModel/JSONModel/JSONModel+Primitive.m
@@ -1,0 +1,18 @@
+//
+//  JSONModel+Primitive.m
+//  JSONModel
+//
+
+#import "JSONModel+Primitive.h"
+#import "JSONModelPrimitiveProtocal.h"
+
+@implementation JSONModel (Primitive)
+
+- (BOOL)allowPrimitiveTypeAsOptioanl {
+    if ([self respondsToSelector:@selector(allowPrimitiveTypeOptioanl)]) {
+        return [(JSONModel<JSONModelPrimitiveProtocol>*)self allowPrimitiveTypeOptioanl];
+    }
+    return NO;
+}
+
+@end

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -14,6 +14,7 @@
 
 #import "JSONModel.h"
 #import "JSONModelClassProperty.h"
+#import "JSONModel+Primitive.h"
 
 #pragma mark - associated objects names
 static const char * kMapperObjectKey;
@@ -289,7 +290,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
         //check for Optional properties
         if (isNull(jsonValue)) {
             //skip this property, continue with next property
-            if (property.isOptional || !validation) continue;
+            if (property.isOptional || [self allowPrimitiveTypeAsOptioanl] || !validation) continue;
 
             if (err) {
                 //null value for required property
@@ -496,7 +497,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
     if (!classRequiredPropertyNames) {
         classRequiredPropertyNames = [NSMutableSet set];
         [[self __properties__] enumerateObjectsUsingBlock:^(JSONModelClassProperty* p, NSUInteger idx, BOOL *stop) {
-            if (!p.isOptional) [classRequiredPropertyNames addObject:p.name];
+            if (!p.isOptional && ![self allowPrimitiveTypeAsOptioanl]) [classRequiredPropertyNames addObject:p.name];
         }];
 
         //persist the list

--- a/JSONModel/JSONModel/JSONModelPrimitiveProtocal.h
+++ b/JSONModel/JSONModel/JSONModelPrimitiveProtocal.h
@@ -1,0 +1,17 @@
+//
+//  JSONModelPrimitiveProtocal.h
+//  JSONModel
+//
+
+@protocol JSONModelPrimitiveProtocol <NSObject>
+
+@required
+
+/**
+ *  Primitive type is considered as a set of the required keys for the model, but sometimes if you do not want to do so,
+ *  you can implement the protocal method 'allowPrimitiveTypeOptioanl' in a model to determine whether the primitive
+ *  type could be a optional or requred type. Returning 'YES' is for optional type, otherwise, 'NO' is for requred type.
+ */
+- (BOOL)allowPrimitiveTypeOptioanl;
+
+@end


### PR DESCRIPTION
For a non-primitive type object, if declaring "< Optioanl >" for it, it can be missing in the input data,
But there's no such function for a primitive type data, such as int, long , float, double, etc.
Hence, I created JSONModelPrimitiveProtocal for solving this problem.It takes the role as the same as JSONModelClassProperty's 'isOptional' property for a primitive type.
For example,
Consider json string as:
```
{
"name":"Jeff",
"age":1
}
```

model as:
```objectivec
@interface TestObject : JSONModel
@property (copy, nonatomic) NSString<Optional> *name;
@property (assign, nonatomic) int year;
@end
```
when calling method "initWithString:error:", it'll will log an error "missing key year"

If do so,

```objectivec
@interface TestObject<JSONModelPrimitiveProtocal>
- (BOOL)allowPrimitiveTypeOptioanl {
    return YES;
}
@end
```

it'll consider year is optional. year property is default to zero. If returning NO, it also log an error saying  "missing key year".

