### PR TITLE
fixed issue for 64b BOOL as string in ipod 5

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -566,6 +566,12 @@ static JSONKeyMapper* globalKeyMapper = nil;
             if ([attributeItems containsObject:@"R"]) {
                 continue; //to next property
             }
+            
+            //check for 64b BOOLs
+            if ([propertyAttributes hasPrefix:@"Tc,"]) {
+                //mask BOOLs as structs so they can have custom converters
+                p.structName = @"BOOL";
+            }
 
             scanner = [NSScanner scannerWithString: propertyAttributes];
 


### PR DESCRIPTION
Was facing an issue with ipod 5 where bool value gets stringified. Last commit has removed this check I guess it is still needed for backward compatibility 