### PR TITLE
Add module map file to targets other than iOS

### DIFF
--- a/JSONModel.xcodeproj/project.pbxproj
+++ b/JSONModel.xcodeproj/project.pbxproj
@@ -538,6 +538,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "$(SRCROOT)/JSONModel/JSONModel.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jsonmodel.JSONModel-mac";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
@@ -564,6 +565,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MODULEMAP_FILE = "$(SRCROOT)/JSONModel/JSONModel.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jsonmodel.JSONModel-mac";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
@@ -588,6 +590,7 @@
 				INFOPLIST_FILE = "JSONModel-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/JSONModel/JSONModel.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jsonmodel.JSONModel-watchOS";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = watchos;
@@ -613,6 +616,7 @@
 				INFOPLIST_FILE = "JSONModel-watchOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/JSONModel/JSONModel.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jsonmodel.JSONModel-watchOS";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = watchos;
@@ -638,6 +642,7 @@
 				INFOPLIST_FILE = "JSONModel-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/JSONModel/JSONModel.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jsonmodel.JSONModel-tvOS";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
@@ -662,6 +667,7 @@
 				INFOPLIST_FILE = "JSONModel-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/JSONModel/JSONModel.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jsonmodel.JSONModel-tvOS";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;


### PR DESCRIPTION
In #482 a module map file was added that fixed an issue when installing
JSONModel with Carthage. But it seems to me that the fix was only applied
to the iOS target (or maybe the other targets were only added later?),
which means I can still see the issue when trying to install on macOS:

    <module-includes>:1:1: error: umbrella header for module 'JSONModel' does not include header 'JSONAPI.h' [-Werror,-Wincomplete-umbrella]
    #import "Headers/JSONModel.h"
    ^
    <module-includes>:1:1: error: umbrella header for module 'JSONModel' does not include header 'JSONHTTPClient.h' [-Werror,-Wincomplete-umbre
    <module-includes>:1:1: error: umbrella header for module 'JSONModel' does not include header 'JSONModel+networking.h' [-Werror,-Wincomplete
    <module-includes>:1:1: error: umbrella header for module 'JSONModel' does not include header 'JSONModelLib.h' [-Werror,-Wincomplete-umbrell
    4 errors generated.

This change adds the module map from #482 to all targets.