### PR TITLE
Optional/ignored properties can be directly queried via the class we're inspecting

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -645,15 +645,15 @@ static JSONKeyMapper* globalKeyMapper = nil;
             }
 
             NSString *nsPropertyName = @(propertyName);
-            if([[self class] propertyIsOptional:nsPropertyName]){
+            if([class propertyIsOptional:nsPropertyName]){
                 p.isOptional = YES;
             }
 
-            if([[self class] propertyIsIgnored:nsPropertyName]){
+            if([class propertyIsIgnored:nsPropertyName]){
                 p = nil;
             }
 
-            Class customClass = [[self class] classForCollectionProperty:nsPropertyName];
+            Class customClass = [class classForCollectionProperty:nsPropertyName];
             if (customClass) {
                 p.protocol = NSStringFromClass(customClass);
             }


### PR DESCRIPTION
I noticed there was an inconsistency with how optional/ignored values are determined. 

In one case, we directly inspect the class that the property belongs to to determine if the property conforms to the respective protocol. 

In the other case (which is addressed in this PR), we query a method that may not necessarily belong to the class we're inspecting, which requires subclasses to query their superclasses for properties that don't belong to them.