### PR TITLE
Fix for __isJSONModelSubClass when JSONModel statically linked into multiple binaries

### DIFF
--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -481,7 +481,7 @@ static JSONKeyMapper* globalKeyMapper = nil;
 -(BOOL)__isJSONModelSubClass:(Class)class
 {
     // JSONModel may be statically linked into multiple loaded binaries (e.g. a dynamic framework and the app itself)
-    // In that case, isSubclassOfClass:JSONModelClass will erroneously return FALSE. Therefore, we'll move the class
+    // In that case, isSubclassOfClass:JSONModelClass will erroneously return FALSE. Therefore, we'll move up the class
     // hierarchy comparing class names to JSONModel
     Class superclass = [class superclass];
     while(superclass)

--- a/JSONModel/JSONModel/JSONModel.m
+++ b/JSONModel/JSONModel/JSONModel.m
@@ -480,12 +480,19 @@ static JSONKeyMapper* globalKeyMapper = nil;
 
 -(BOOL)__isJSONModelSubClass:(Class)class
 {
-// http://stackoverflow.com/questions/19883472/objc-nsobject-issubclassofclass-gives-incorrect-failure
-#ifdef UNIT_TESTING
-    return [@"JSONModel" isEqualToString: NSStringFromClass([class superclass])];
-#else
-    return [class isSubclassOfClass:JSONModelClass];
-#endif
+    // JSONModel may be statically linked into multiple loaded binaries (e.g. a dynamic framework and the app itself)
+    // In that case, isSubclassOfClass:JSONModelClass will erroneously return FALSE. Therefore, we'll move the class
+    // hierarchy comparing class names to JSONModel
+    Class superclass = [class superclass];
+    while(superclass)
+    {
+        if([@"JSONModel" isEqualToString: NSStringFromClass(superclass)])
+        {
+            return TRUE;
+        }
+        superclass = [superclass superclass];
+    }
+    return FALSE;
 }
 
 //returns a set of the required keys for the model


### PR DESCRIPTION
Hard to write a unit test for this, but it looks like there was already code that was trying to address this in the unit tests that were running. This just extends that to run always, and to keep moving up the class hierarchy in case there are intermediate classes between the class passed in and `JSONModel`